### PR TITLE
165 controller unplug

### DIFF
--- a/Booom/Assets/Scripts/LobbyManager.cs
+++ b/Booom/Assets/Scripts/LobbyManager.cs
@@ -148,6 +148,8 @@ public class LobbyManager : MonoBehaviour
     
     private void OnInputUserChange(InputUser user, InputUserChange change, InputDevice device)
     {
+        if (SceneManager.GetActiveScene().name != "Menu") return;
+        
         if (change == InputUserChange.DeviceLost)
         {
             PlayerInput pi = PlayerInput.all.FirstOrDefault(p => p.user == user);


### PR DESCRIPTION
Selon UnityEngine.InputSystem.Users, la fonction InputUserChange.DeviceLost est caller quand la manette manque de batterie ou est unplugged. Jai verifier pour quand la manette se deplug mais g pas reussi en eteignant ma manette de ps5... weird. Mais debrancher ca fonctionne. Ah pi je fais juste handle le menu pcq si on debranche mid game on veut pas detruire le player lol Unity va faire comme avant pi retrouver le device


Closes #165 